### PR TITLE
Add query for num_of_days

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -517,6 +517,7 @@ fn main() {
         .clear()
         .append_pair("q", &city)
         .append_pair("key", KEY)
+        .append_pair("num_of_days", &num_of_days.to_string())
         .append_pair("lang", "zh")
         .append_pair("format", "json");
 


### PR DESCRIPTION
According to current [API](https://developer.worldweatheronline.com/api/docs/local-city-town-weather-api.aspx), the parameter `num_of_days` is required.
